### PR TITLE
[frontend] chore: Increasing api timeout

### DIFF
--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -10,6 +10,8 @@ const api = axios.create({
     'Content-Type': 'application/json',
     Authorization: `Bearer ${localStorage.getItem('token')}`,
   },
+  timeout: 2 * 60 * 1000,
+  signal: AbortSignal.timeout(2 * 60 * 1000),
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
Due to free tier hosting taking > 60 seconds to come online, increasing the axios timeouts