### PR TITLE
[production-tests] chore: Curl to wake backend before tests

### DIFF
--- a/.github/workflows/playwright-production-tests.yml
+++ b/.github/workflows/playwright-production-tests.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: 20.x
 
     - name: Wake backend
-      run: curl -v --connect-timeout 120 -m 180 ${API_URL}
+      run: curl -v --connect-timeout 120 -m 180 ${HEALTH_URL}
 
     - name: Install Playwright
       run: |

--- a/.github/workflows/playwright-production-tests.yml
+++ b/.github/workflows/playwright-production-tests.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    env:
+      HEALTH_URL: https://notes-app-full-stack-be.onrender.com/health
     steps:
     - uses: actions/checkout@v4
 
@@ -20,6 +22,9 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 20.x
+
+    - name: Wake backend
+      run: curl -v --connect-timeout 120 -m 180 ${API_URL}
 
     - name: Install Playwright
       run: |


### PR DESCRIPTION
Attempting to start BE before the production tests